### PR TITLE
ci(react-doctor): pin version and fix flatMap warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,11 @@ jobs:
     name: React Doctor
     needs: [lint-fe, typecheck-fe]
     runs-on: ubuntu-latest
+    env:
+      # Pin react-doctor to a known-good version. The upstream millionco/react-doctor action
+      # invokes react-doctor@latest internally, which makes CI non-reproducible when new
+      # rules ship upstream. Bump this deliberately after reviewing release notes.
+      REACT_DOCTOR_VERSION: "0.0.37"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -150,13 +155,16 @@ jobs:
       - run: npm ci
         working-directory: frontend
       - name: React Doctor
-        id: react_doctor
-        uses: millionco/react-doctor@main
-        with:
-          directory: frontend
-      - name: Check React Doctor score
+        working-directory: frontend
+        env:
+          NO_COLOR: "1"
+        run: npx -y "react-doctor@${REACT_DOCTOR_VERSION}" . --fail-on error --verbose
+      - name: React Doctor score
+        id: react_doctor_score
+        if: always()
+        working-directory: frontend
         run: |
-          score="${{ steps.react_doctor.outputs.score }}"
+          score=$(npx -y "react-doctor@${REACT_DOCTOR_VERSION}" . --score 2>/dev/null | tail -1 | tr -d '[:space:]')
           echo "React Doctor score: ${score:-unknown}/100"
           if [ -z "$score" ] || [ "$score" -lt 100 ]; then
             echo "::error::React Doctor score below 100 (got: ${score:-unknown})"

--- a/frontend/src/components/timeline/timelineMarkers.tsx
+++ b/frontend/src/components/timeline/timelineMarkers.tsx
@@ -389,8 +389,10 @@ function TraumaMarkersInner({ ctx, events }: TraumaMarkersProps) {
         const { x: mx, y: my } = orientation.pointAt(year);
         const primaryPos = orientation.primaryPos(year);
         const linkedNames = event.person_ids
-          .map((pid) => persons.get(pid)?.name)
-          .filter(Boolean)
+          .flatMap((pid) => {
+            const name = persons.get(pid)?.name;
+            return name ? [name] : [];
+          })
           .join(", ");
 
         const isMarkerDimmed = dims?.dimmedEventIds.has(event.id);
@@ -486,8 +488,10 @@ function TurningPointMarkersInner({ ctx, turningPoints }: TurningPointMarkersPro
         const path = starPath(mx, my, r);
 
         const linkedNames = tp.person_ids
-          .map((pid) => persons.get(pid)?.name)
-          .filter(Boolean)
+          .flatMap((pid) => {
+            const name = persons.get(pid)?.name;
+            return name ? [name] : [];
+          })
           .join(", ");
 
         const lines: TooltipLine[] = [
@@ -576,8 +580,10 @@ function LifeEventMarkersInner({ ctx, lifeEvents }: LifeEventMarkersProps) {
         const primaryPos = orientation.primaryPos(year);
         const diamondSize = MARKER_RADIUS * 0.9;
         const linkedNames = le.person_ids
-          .map((pid) => persons.get(pid)?.name)
-          .filter(Boolean)
+          .flatMap((pid) => {
+            const name = persons.get(pid)?.name;
+            return name ? [name] : [];
+          })
           .join(", ");
 
         const lines: TooltipLine[] = [

--- a/frontend/src/components/tree/LifeEventsTab.tsx
+++ b/frontend/src/components/tree/LifeEventsTab.tsx
@@ -79,10 +79,10 @@ function LifeEventForm({
         category: state.category,
         approximate_date: state.approximateDate,
         impact: state.impact ? parseInt(state.impact, 10) || null : null,
-        tags: state.tags
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean),
+        tags: state.tags.split(",").flatMap((s) => {
+          const trimmed = s.trim();
+          return trimmed ? [trimmed] : [];
+        }),
       },
       Array.from(selectedPersonIds),
     );

--- a/frontend/src/components/tree/PersonLinkField.tsx
+++ b/frontend/src/components/tree/PersonLinkField.tsx
@@ -13,8 +13,10 @@ export function PersonLinkField({ allPersons, selectedIds, onChange }: PersonLin
   const [expanded, setExpanded] = useState(false);
 
   const selectedNames = [...selectedIds]
-    .map((id) => allPersons.get(id)?.name)
-    .filter(Boolean)
+    .flatMap((id) => {
+      const name = allPersons.get(id)?.name;
+      return name ? [name] : [];
+    })
     .join(", ");
 
   const sortedPersons = [...allPersons.values()].sort((a, b) => a.name.localeCompare(b.name));

--- a/frontend/src/components/tree/TraumaEventsTab.tsx
+++ b/frontend/src/components/tree/TraumaEventsTab.tsx
@@ -142,10 +142,10 @@ function EventForm({ event, allPersons, initialPersonIds, onSave, onDelete }: Ev
         category: state.category,
         approximate_date: state.approximateDate,
         severity: parseInt(state.severity, 10) || 1,
-        tags: state.tags
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean),
+        tags: state.tags.split(",").flatMap((s) => {
+          const trimmed = s.trim();
+          return trimmed ? [trimmed] : [];
+        }),
       },
       Array.from(selectedPersonIds),
     );

--- a/frontend/src/components/tree/TurningPointsTab.tsx
+++ b/frontend/src/components/tree/TurningPointsTab.tsx
@@ -87,10 +87,10 @@ function TurningPointForm({
         category: state.category,
         approximate_date: state.approximateDate,
         significance: state.significance ? parseInt(state.significance, 10) || null : null,
-        tags: state.tags
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean),
+        tags: state.tags.split(",").flatMap((s) => {
+          const trimmed = s.trim();
+          return trimmed ? [trimmed] : [];
+        }),
       },
       Array.from(selectedPersonIds),
     );


### PR DESCRIPTION
## Summary

Unblocks all open Dependabot PRs by fixing the React Doctor gate.

- Pin `react-doctor` to `0.0.37` in `ci.yml` via a `REACT_DOCTOR_VERSION` env var. The upstream `millionco/react-doctor@main` action invokes `react-doctor@latest` internally, so the 0.0.34→0.0.37 releases (2026-04-15/16) introduced a new rule that silently broke CI on every PR created after that date — including all of main's own branches.
- Convert seven `.map(...).filter(Boolean)` patterns to `.flatMap(...)` in `TraumaEventsTab`, `LifeEventsTab`, `TurningPointsTab`, `PersonLinkField`, and `timelineMarkers` so the gate scores 100/100 under the pinned version.

The new workflow step calls `npx -y react-doctor@${REACT_DOCTOR_VERSION}` directly instead of relying on the action, so version bumps are deliberate and reviewable in a diff.

## Test plan

- [x] `npx react-doctor@0.0.37 . --score` reports `100` locally
- [x] `docker compose exec frontend npx tsc --noEmit` clean
- [x] `docker compose exec frontend npx vitest run --project unit` — 331/331 passing
- [x] `docker compose exec frontend npx vitest run --project integration` — 1948/1948 passing
- [ ] CI confirms React Doctor gate passes on this branch